### PR TITLE
Add support to any type on the left operator and Map as input data

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![Maven Central](https://img.shields.io/maven-central/v/com.rapatao.ruleset/ruleset-engine.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:com.rapatao.ruleset%20AND%20a:ruleset-engine)
 [![Sonatype OSS](https://img.shields.io/nexus/r/com.rapatao.ruleset/ruleset-engine?label=Sonatype%20OSS&server=https%3A%2F%2Foss.sonatype.org)](https://ossindex.sonatype.org/component/pkg:maven/com.rapatao.ruleset/ruleset-engine)
 
-A simple rule engine that uses [Rhino](https://github.com/mozilla/rhino) implementation of JavaScript to evaluate expressions.
+A simple rule engine that uses [Rhino](https://github.com/mozilla/rhino) implementation of JavaScript to evaluate
+expressions.
 
 ## Get started
 
@@ -37,23 +38,23 @@ To create custom operations, just extends the interface `com.rapatao.projects.ru
 ### Examples
 
 ````kotlin
-field("field").isTrue()
+left("field").isTrue()
 
-field("field") equalsTo 10
+left("field") equalsTo 10
 
-field("field") equalsTo "\"value\""
+left("field") equalsTo "\"value\""
 
-field("field") equalsTo "value"
+left("field") equalsTo "value"
 
-field("field") between 10 and 20
+left("field") between 10 and 20
 
-field("field") greaterThan 10
+left("field") greaterThan 10
 
-field("field") greaterOrEqualThan 10
+left("field") greaterOrEqualThan 10
 
-field("field") lessThan 10
+left("field") lessThan 10
 
-field("field") lessOrEqualThan 10
+left("field") lessOrEqualThan 10
 ````
 
 ## Supported group operations
@@ -120,41 +121,229 @@ val asMatcher: Matcher = mapper.readValue(json)
 ### Examples
 
 ```json
-{"expression":{"left":"field","operator":"EQUALS","right":true}}
+{
+    "expression": {
+        "left": "field",
+        "operator": "EQUALS",
+        "right": true
+    }
+}
 ```
+
 ```json
-{"expression":{"left":"field","operator":"EQUALS","right":10}}
+{
+    "expression": {
+        "left": "field",
+        "operator": "EQUALS",
+        "right": 10
+    }
+}
 ```
+
 ```json
-{"expression":{"left":"field","operator":"EQUALS","right":"\"value\""}}
+{
+    "expression": {
+        "left": "field",
+        "operator": "EQUALS",
+        "right": "\"value\""
+    }
+}
 ```
+
 ```json
-{"expression":{"left":"field","operator":"EQUALS","right":"value"}}
+{
+    "expression": {
+        "left": "field",
+        "operator": "EQUALS",
+        "right": "value"
+    }
+}
 ```
+
 ```json
-{"expression":{"value":"field","from":10,"to":20}}
+{
+    "expression": {
+        "value": "field",
+        "from": 10,
+        "to": 20
+    }
+}
 ```
+
 ```json
-{"expression":{"left":"field","operator":"GREATER_THAN","right":10}}
+{
+    "expression": {
+        "left": "field",
+        "operator": "GREATER_THAN",
+        "right": 10
+    }
+}
 ```
+
 ```json
-{"expression":{"left":"field","operator":"GREATER_OR_EQUAL_THAN","right":10}}
+{
+    "expression": {
+        "left": "field",
+        "operator": "GREATER_OR_EQUAL_THAN",
+        "right": 10
+    }
+}
 ```
+
 ```json
-{"expression":{"left":"field","operator":"LESS_THAN","right":10}}
+{
+    "expression": {
+        "left": "field",
+        "operator": "LESS_THAN",
+        "right": 10
+    }
+}
 ```
+
 ```json
-{"expression":{"left":"field","operator":"LESS_OR_EQUAL_THAN","right":10}}
+{
+    "expression": {
+        "left": "field",
+        "operator": "LESS_OR_EQUAL_THAN",
+        "right": 10
+    }
+}
 ```
+
 ```json
-{"allMatch":[{"expression":{"left":"field","operator":"EQUALS","right":true}},{"expression":{"left":"price","operator":"LESS_THAN","right":10.0}}]}
+{
+    "allMatch": [
+        {
+            "expression": {
+                "left": "field",
+                "operator": "EQUALS",
+                "right": true
+            }
+        },
+        {
+            "expression": {
+                "left": "price",
+                "operator": "LESS_THAN",
+                "right": 10.0
+            }
+        }
+    ]
+}
 ```
+
 ```json
-{"anyMatch":[{"expression":{"left":"field","operator":"EQUALS","right":true}},{"expression":{"left":"price","operator":"LESS_THAN","right":10.0}}]}
+{
+    "anyMatch": [
+        {
+            "expression": {
+                "left": "field",
+                "operator": "EQUALS",
+                "right": true
+            }
+        },
+        {
+            "expression": {
+                "left": "price",
+                "operator": "LESS_THAN",
+                "right": 10.0
+            }
+        }
+    ]
+}
 ```
+
 ```json
-{"noneMatch":[{"expression":{"left":"field","operator":"EQUALS","right":true}},{"expression":{"left":"price","operator":"LESS_THAN","right":10.0}}]}
+{
+    "noneMatch": [
+        {
+            "expression": {
+                "left": "field",
+                "operator": "EQUALS",
+                "right": true
+            }
+        },
+        {
+            "expression": {
+                "left": "price",
+                "operator": "LESS_THAN",
+                "right": 10.0
+            }
+        }
+    ]
+}
 ```
+
 ```json
-{"allMatch":[{"expression":{"left":"field","operator":"EQUALS","right":true}},{"expression":{"left":"price","operator":"LESS_THAN","right":10.0}}],"anyMatch":[{"expression":{"left":"field","operator":"EQUALS","right":true}},{"expression":{"left":"price","operator":"LESS_THAN","right":10.0}}],"noneMatch":[{"expression":{"left":"field","operator":"EQUALS","right":true}},{"expression":{"left":"price","operator":"LESS_THAN","right":10.0}}]}
+{
+    "allMatch": [
+        {
+            "expression": {
+                "left": "field",
+                "operator": "EQUALS",
+                "right": true
+            }
+        },
+        {
+            "expression": {
+                "left": "price",
+                "operator": "LESS_THAN",
+                "right": 10.0
+            }
+        }
+    ],
+    "anyMatch": [
+        {
+            "expression": {
+                "left": "field",
+                "operator": "EQUALS",
+                "right": true
+            }
+        },
+        {
+            "expression": {
+                "left": "price",
+                "operator": "LESS_THAN",
+                "right": 10.0
+            }
+        }
+    ],
+    "noneMatch": [
+        {
+            "expression": {
+                "left": "field",
+                "operator": "EQUALS",
+                "right": true
+            }
+        },
+        {
+            "expression": {
+                "left": "price",
+                "operator": "LESS_THAN",
+                "right": 10.0
+            }
+        }
+    ]
+}
+```
+
+### Example of usage
+
+```kotlin
+import com.rapatao.projects.ruleset.engine.Evaluator
+import com.rapatao.projects.ruleset.engine.types.builder.ExpressionBuilder.left
+import com.rapatao.projects.ruleset.engine.types.builder.MatcherBuilder
+
+val rule = MatcherBuilder.expression(left("item.price") equalsTo 0)
+
+val evaluator = Evaluator()
+
+val result = evaluator.evaluate(rule, mapOf("item" to mapOf("price" to 0)))
+println(result) // true
+
+
+data class Item(val price: Double)
+data class Input(val item: Item)
+
+val result2 = evaluator.evaluate(rule, Input(item = Item(price = 0.0)))
+println(result) // true
 ```

--- a/README.md
+++ b/README.md
@@ -143,6 +143,16 @@ val asMatcher: Matcher = mapper.readValue(json)
 ```json
 {
     "expression": {
+        "left": 10,
+        "operator": "EQUALS",
+        "right": 10
+    }
+}
+```
+
+```json
+{
+    "expression": {
         "left": "field",
         "operator": "EQUALS",
         "right": "\"value\""
@@ -163,7 +173,7 @@ val asMatcher: Matcher = mapper.readValue(json)
 ```json
 {
     "expression": {
-        "value": "field",
+        "left": "field",
         "from": 10,
         "to": 20
     }

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group "com.rapatao.ruleset"
-version "0.0.2-SNAPSHOT"
+version "0.1.0-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,12 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlinx:kover:${koverVersion}"
-    }
-}
+import kotlinx.kover.gradle.plugin.dsl.MetricType
 
 plugins {
-    id "org.jetbrains.kotlin.jvm" version "${kotlinVersion}"
     id "java-library"
-    id "io.gitlab.arturbosch.detekt" version "${detektVersion}"
-    id "org.jetbrains.kotlinx.kover" version "${koverVersion}"
     id "signing"
     id 'maven-publish'
+    id "org.jetbrains.kotlin.jvm" version "${kotlinVersion}"
+    id "io.gitlab.arturbosch.detekt" version "${detektVersion}"
+    id "org.jetbrains.kotlinx.kover" version "${koverVersion}"
 }
 
 group "com.rapatao.ruleset"
@@ -51,27 +44,30 @@ java {
 detekt {
     buildUponDefaultConfig = true
     allRules = false
+}
 
-    reports {
-        html.enabled = true
-        xml.enabled = true
-        txt.enabled = true
-        sarif.enabled = true
+koverReport {
+    verify {
+        rule {
+            enabled = true
+            bound {
+                metric = MetricType.BRANCH
+                minValue = 80
+            }
+            bound {
+                metric = MetricType.LINE
+                minValue = 90
+            }
+            bound {
+                metric = MetricType.INSTRUCTION
+                minValue = 90
+            }
+        }
     }
-}
 
-kover {
-    enabled = true
-    coverageEngine.set(kotlinx.kover.api.CoverageEngine.JACOCO)
-    jacocoEngineVersion.set("${jacocoVersion}")
-    generateReportOnCheck.set(true)
-}
-
-tasks.koverVerify {
-    rule {
-        name = "Minimal line coverage rate in percents"
-        bound {
-            minValue = 90
+    defaults {
+        html {
+            onCheck = true
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
-detektVersion=1.18.1
+detektVersion=1.23.1
 hamcrestVersion=2.2
-jacksonVersion=2.13.0
+jacksonVersion=2.15.2
 jacocoVersion=0.8.7
-junitVersion=5.8.1
-kotlinVersion=1.6.0
-koverVersion=0.4.2
-rhinoVersion=1.7.13
+junitVersion=5.10.0
+kotlinVersion=1.9.10
+koverVersion=0.7.3
+rhinoVersion=1.7.14

--- a/src/main/kotlin/com/rapatao/projects/ruleset/engine/InternalContextFactory.kt
+++ b/src/main/kotlin/com/rapatao/projects/ruleset/engine/InternalContextFactory.kt
@@ -1,0 +1,63 @@
+package com.rapatao.projects.ruleset.engine
+
+import org.mozilla.javascript.Context
+import org.mozilla.javascript.ContextFactory
+import org.mozilla.javascript.ScriptableObject
+import kotlin.reflect.full.memberProperties
+
+internal class InternalContextFactory : ContextFactory() {
+    override fun hasFeature(cx: Context?, featureIndex: Int): Boolean {
+        if (Context.FEATURE_ENABLE_JAVA_MAP_ACCESS == featureIndex) {
+            return true
+        }
+
+        return super.hasFeature(cx, featureIndex)
+    }
+
+    fun call(
+        inputData: Any,
+        block: (context: Context, scope: ScriptableObject, params: List<String>) -> Boolean
+    ): Boolean {
+        return this.call { context ->
+            context.optimizationLevel = -1
+
+            val scope = context.initSafeStandardObjects()
+
+            val params = parseParameters(inputData, scope, context)
+
+            block(context, scope, params)
+        }
+    }
+
+    private fun parseParameters(
+        inputData: Any,
+        scope: ScriptableObject,
+        context: Context,
+    ): List<String> {
+        return when (inputData) {
+            is Map<*, *> -> {
+                inputData.onEach {
+                    ScriptableObject.putConstProperty(
+                        scope,
+                        it.key.toString(),
+                        Context.javaToJS(it.value, scope)
+                    )
+                }.map {
+                    it.key.toString()
+                }
+            }
+
+            else -> {
+                inputData.javaClass.kotlin.memberProperties
+                    .onEach {
+                        ScriptableObject.putConstProperty(
+                            scope,
+                            it.name,
+                            Context.javaToJS(it.get(inputData), scope, context)
+                        )
+                    }
+                    .map { it.name }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/BetweenExpression.kt
+++ b/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/BetweenExpression.kt
@@ -1,9 +1,9 @@
 package com.rapatao.projects.ruleset.engine.types
 
 data class BetweenExpression(
-    val value: String,
+    val left: Any,
     val from: Any,
     val to: Any
 ) : Expression {
-    override fun parse(): String = "$value >= $from && $value <= $to"
+    override fun parse(): String = "$left >= $from && $left <= $to"
 }

--- a/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/BooleanExpression.kt
+++ b/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/BooleanExpression.kt
@@ -1,11 +1,14 @@
 package com.rapatao.projects.ruleset.engine.types
 
 data class BooleanExpression(
-    val left: String,
+    val left: Any,
     val operator: Operator,
     val right: Any,
 ) : Expression {
-    override fun parse(): String = "$left ${operator.operator} $right"
+
+    override fun parse(): String {
+        return "$left ${operator.operator} ${wrap(right)}"
+    }
 
     enum class Operator(
         val operator: String

--- a/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/BooleanExpression.kt
+++ b/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/BooleanExpression.kt
@@ -7,7 +7,7 @@ data class BooleanExpression(
 ) : Expression {
 
     override fun parse(): String {
-        return "$left ${operator.operator} ${wrap(right)}"
+        return "$left ${operator.operator} $right"
     }
 
     enum class Operator(

--- a/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/Expression.kt
+++ b/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/Expression.kt
@@ -2,4 +2,11 @@ package com.rapatao.projects.ruleset.engine.types
 
 interface Expression {
     fun parse(): String
+
+    fun wrap(value: Any): Any {
+        if (value is String && value.contains(" ")) {
+            return "\"$value\""
+        }
+        return value
+    }
 }

--- a/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/Expression.kt
+++ b/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/Expression.kt
@@ -1,12 +1,5 @@
 package com.rapatao.projects.ruleset.engine.types
 
-interface Expression {
+fun interface Expression {
     fun parse(): String
-
-    fun wrap(value: Any): Any {
-        if (value is String && value.contains(" ")) {
-            return "\"$value\""
-        }
-        return value
-    }
 }

--- a/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/builder/ExpressionBuilder.kt
+++ b/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/builder/ExpressionBuilder.kt
@@ -10,29 +10,34 @@ import com.rapatao.projects.ruleset.engine.types.BooleanExpression.Operator.LESS
 
 object ExpressionBuilder {
 
-    fun field(field: String) = Builder(field)
+    @Deprecated("use ExpressionBuilder.left method",
+        ReplaceWith("left(left)", "com.rapatao.projects.ruleset.engine.types.builder.ExpressionBuilder.left")
+    )
+    fun field(left: String) = left(left)
 
-    fun isTrue(expression: String) = BooleanExpression(expression, EQUALS, true)
+    fun left(left: Any) = Builder(left)
 
-    class Builder(private val field: String) {
-        infix fun equalsTo(value: Any) = BooleanExpression(field, EQUALS, value)
+    fun isTrue(expression: Any) = BooleanExpression(expression, EQUALS, true)
 
-        infix fun between(value: Any) = BetweenBuilder(value)
+    class Builder(private val left: Any) {
+        infix fun equalsTo(right: Any) = BooleanExpression(left, EQUALS, right)
 
-        infix fun greaterThan(value: Any) = BooleanExpression(field, GREATER_THAN, value)
+        infix fun between(from: Any) = BetweenBuilder(from)
 
-        infix fun greaterOrEqualThan(value: Any) = BooleanExpression(field, GREATER_OR_EQUAL_THAN, value)
+        infix fun greaterThan(right: Any) = BooleanExpression(left, GREATER_THAN, right)
 
-        infix fun lessThan(value: Any) = BooleanExpression(field, LESS_THAN, value)
+        infix fun greaterOrEqualThan(right: Any) = BooleanExpression(left, GREATER_OR_EQUAL_THAN, right)
 
-        infix fun lessOrEqualThan(value: Any) = BooleanExpression(field, LESS_OR_EQUAL_THAN, value)
+        infix fun lessThan(right: Any) = BooleanExpression(left, LESS_THAN, right)
 
-        fun isTrue() = BooleanExpression(field, EQUALS, true)
+        infix fun lessOrEqualThan(right: Any) = BooleanExpression(left, LESS_OR_EQUAL_THAN, right)
 
-        fun isFalse() = BooleanExpression(field, EQUALS, false)
+        fun isTrue() = BooleanExpression(left, EQUALS, true)
 
-        inner class BetweenBuilder(private val value: Any) {
-            infix fun and(to: Any) = BetweenExpression(field, value, to)
+        fun isFalse() = BooleanExpression(left, EQUALS, false)
+
+        inner class BetweenBuilder(private val from: Any) {
+            infix fun and(to: Any) = BetweenExpression(left, from, to)
         }
     }
 }

--- a/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/builder/MatcherBuilder.kt
+++ b/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/builder/MatcherBuilder.kt
@@ -6,7 +6,7 @@ import com.rapatao.projects.ruleset.engine.types.builder.ExpressionBuilder.isTru
 
 object MatcherBuilder {
     fun expression(expression: Expression) = Matcher(expression = expression)
-    fun expression(expression: String) = Matcher(expression = isTrue(expression))
+    fun expression(expression: Any) = Matcher(expression = isTrue(expression))
     fun allMatch(vararg matchers: Matcher) = Matcher(allMatch = matchers.toList())
     fun anyMatch(vararg matchers: Matcher) = Matcher(anyMatch = matchers.toList())
     fun noneMatch(vararg matchers: Matcher) = Matcher(noneMatch = matchers.toList())

--- a/src/test/kotlin/com/rapatao/projects/ruleset/SerializationExamplesBuilder.kt
+++ b/src/test/kotlin/com/rapatao/projects/ruleset/SerializationExamplesBuilder.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.rapatao.projects.ruleset.engine.types.Expression
 import com.rapatao.projects.ruleset.engine.types.Matcher
-import com.rapatao.projects.ruleset.engine.types.builder.ExpressionBuilder.field
 import com.rapatao.projects.ruleset.engine.types.builder.ExpressionBuilder.isTrue
+import com.rapatao.projects.ruleset.engine.types.builder.ExpressionBuilder.left
 import com.rapatao.projects.ruleset.engine.types.builder.MatcherBuilder.allMatch
 import com.rapatao.projects.ruleset.engine.types.builder.MatcherBuilder.anyMatch
 import com.rapatao.projects.ruleset.engine.types.builder.MatcherBuilder.expression
@@ -21,40 +21,40 @@ internal class SerializationExamplesBuilder {
         .addMixIn(Expression::class.java, ExpressionMixin::class.java)
 
     private val cases = listOf(
-        expression(field("field").isTrue()),
-        expression(field("field") equalsTo 10),
-        expression(field("field") equalsTo "\"value\""),
-        expression(field("field") equalsTo "value"),
-        expression(field("field") between 10 and 20),
-        expression(field("field") greaterThan 10),
-        expression(field("field") greaterOrEqualThan 10),
-        expression(field("field") lessThan 10),
-        expression(field("field") lessOrEqualThan 10),
+        expression(left("field").isTrue()),
+        expression(left("field") equalsTo 10),
+        expression(left("field") equalsTo "\"value\""),
+        expression(left("field") equalsTo "value"),
+        expression(left("field") between 10 and 20),
+        expression(left("field") greaterThan 10),
+        expression(left("field") greaterOrEqualThan 10),
+        expression(left("field") lessThan 10),
+        expression(left("field") lessOrEqualThan 10),
 
         allMatch(
             expression(isTrue("field")),
-            expression(field("price").lessThan(10.0)),
+            expression(left("price").lessThan(10.0)),
         ),
         anyMatch(
             expression(isTrue("field")),
-            expression(field("price").lessThan(10.0)),
+            expression(left("price").lessThan(10.0)),
         ),
         noneMatch(
             expression(isTrue("field")),
-            expression(field("price").lessThan(10.0)),
+            expression(left("price").lessThan(10.0)),
         ),
         Matcher(
             allMatch = listOf(
                 expression(isTrue("field")),
-                expression(field("price").lessThan(10.0)),
+                expression(left("price").lessThan(10.0)),
             ),
             anyMatch = listOf(
                 expression(isTrue("field")),
-                expression(field("price").lessThan(10.0)),
+                expression(left("price").lessThan(10.0)),
             ),
             noneMatch = listOf(
                 expression(isTrue("field")),
-                expression(field("price").lessThan(10.0)),
+                expression(left("price").lessThan(10.0)),
             )
         )
     )

--- a/src/test/kotlin/com/rapatao/projects/ruleset/SerializationExamplesBuilder.kt
+++ b/src/test/kotlin/com/rapatao/projects/ruleset/SerializationExamplesBuilder.kt
@@ -23,6 +23,7 @@ internal class SerializationExamplesBuilder {
     private val cases = listOf(
         expression(left("field").isTrue()),
         expression(left("field") equalsTo 10),
+        expression(left(10) equalsTo 10),
         expression(left("field") equalsTo "\"value\""),
         expression(left("field") equalsTo "value"),
         expression(left("field") between 10 and 20),

--- a/src/test/kotlin/com/rapatao/projects/ruleset/engine/EvaluatorTest.kt
+++ b/src/test/kotlin/com/rapatao/projects/ruleset/engine/EvaluatorTest.kt
@@ -106,8 +106,8 @@ internal class EvaluatorTest {
 
         val rule = allMatch(
             expression(left("item.price") equalsTo 0),
-            expression(left("attributes.info.title") equalsTo "superb title"),
-            expression(left("attributes.info.description") equalsTo "super description")
+            expression(left("attributes.info.title") equalsTo "\"superb title\""),
+            expression(left("attributes.info.description") equalsTo "\"super description\"")
         )
 
         val evaluator = Evaluator()

--- a/src/test/kotlin/com/rapatao/projects/ruleset/engine/cases/ExpressionCases.kt
+++ b/src/test/kotlin/com/rapatao/projects/ruleset/engine/cases/ExpressionCases.kt
@@ -1,7 +1,7 @@
 package com.rapatao.projects.ruleset.engine.cases
 
 import com.rapatao.projects.ruleset.engine.types.BetweenExpression
-import com.rapatao.projects.ruleset.engine.types.builder.ExpressionBuilder.field
+import com.rapatao.projects.ruleset.engine.types.builder.ExpressionBuilder.left
 import com.rapatao.projects.ruleset.engine.types.builder.MatcherBuilder.expression
 import org.junit.jupiter.params.provider.Arguments
 import java.math.BigDecimal
@@ -20,7 +20,7 @@ object ExpressionCases {
         ),
         Arguments.of(
             expression(
-                field("item.price") between 1 and 1000
+                left("item.price") between 1 and 1000
             ),
             true
         ),
@@ -38,92 +38,92 @@ object ExpressionCases {
         ),
         Arguments.of(
             expression(
-                field("item.price") equalsTo BigDecimal.TEN
+                left("item.price") equalsTo BigDecimal.TEN
             ),
             true
         ),
         Arguments.of(
             expression(
-                field("item.price") equalsTo BigDecimal.ZERO
+                left("item.price") equalsTo BigDecimal.ZERO
             ),
             false
         ),
         Arguments.of(
             expression(
-                field("item.trueValue").isTrue()
+                left("item.trueValue").isTrue()
             ),
             true
         ),
         Arguments.of(
             expression(
-                field("item.trueValue").isFalse()
+                left("item.trueValue").isFalse()
             ),
             false
         ),
         Arguments.of(
             expression(
-                field("item.falseValue").isTrue()
+                left("item.falseValue").isTrue()
             ),
             false
         ),
         Arguments.of(
             expression(
-                field("item.falseValue").isFalse()
+                left("item.falseValue").isFalse()
             ),
             true
         ),
         Arguments.of(
             expression(
-                field("item.price") greaterThan BigDecimal.ZERO
+                left("item.price") greaterThan BigDecimal.ZERO
             ),
             true
         ),
         Arguments.of(
             expression(
-                field("item.price") greaterThan BigDecimal.TEN
+                left("item.price") greaterThan BigDecimal.TEN
             ),
             false
         ),
         Arguments.of(
             expression(
-                field("item.price") greaterOrEqualThan BigDecimal.TEN
+                left("item.price") greaterOrEqualThan BigDecimal.TEN
             ),
             true
         ),
         Arguments.of(
             expression(
-                field("item.price") greaterOrEqualThan BigDecimal.valueOf(100)
+                left("item.price") greaterOrEqualThan BigDecimal.valueOf(100)
             ),
             false
         ),
         Arguments.of(
             expression(
-                field("item.price") lessThan BigDecimal.valueOf(100)
+                left("item.price") lessThan BigDecimal.valueOf(100)
             ),
             true
         ),
         Arguments.of(
             expression(
-                field("item.price") lessThan BigDecimal.ONE
+                left("item.price") lessThan BigDecimal.ONE
             ),
             false
         ),
         // 43
         Arguments.of(
             expression(
-                field("item.price") lessOrEqualThan BigDecimal.valueOf(100)
+                left("item.price") lessOrEqualThan BigDecimal.valueOf(100)
             ),
             true
         ),
         Arguments.of(
             expression(
-                field("item.price") lessOrEqualThan BigDecimal.TEN
+                left("item.price") lessOrEqualThan BigDecimal.TEN
             ),
             true
         ),
         Arguments.of(
             expression(
-                field("item.price") lessOrEqualThan BigDecimal.ONE
+                left("item.price") lessOrEqualThan BigDecimal.ONE
             ),
             false
         ),

--- a/src/test/kotlin/com/rapatao/projects/ruleset/engine/cases/MatcherCases.kt
+++ b/src/test/kotlin/com/rapatao/projects/ruleset/engine/cases/MatcherCases.kt
@@ -224,5 +224,9 @@ object MatcherCases {
             ),
             false
         ),
+        Arguments.of(
+            expression(true),
+            true
+        ),
     )
 }


### PR DESCRIPTION
The change adds support to evaluate rules using other data than a field on the left operator and support.

It also adds support to evaluate map as input data, parsing its keys/values as it were properties of a mapped class.