### PR TITLE
feat: parent onFailure configuration

### DIFF
--- a/src/main/kotlin/com/rapatao/projects/ruleset/engine/evaluator/rhino/RhinoContext.kt
+++ b/src/main/kotlin/com/rapatao/projects/ruleset/engine/evaluator/rhino/RhinoContext.kt
@@ -2,7 +2,6 @@ package com.rapatao.projects.ruleset.engine.evaluator.rhino
 
 import com.rapatao.projects.ruleset.engine.context.EvalContext
 import com.rapatao.projects.ruleset.engine.types.Expression
-import com.rapatao.projects.ruleset.engine.types.OnFailure
 import org.mozilla.javascript.Context
 import org.mozilla.javascript.Script
 import org.mozilla.javascript.ScriptableObject
@@ -27,16 +26,8 @@ class RhinoContext(
      * @throws Exception if the expression processing fails and onFailure is set to THROW
      */
     override fun process(expression: Expression): Boolean {
-        return try {
-            true == expression.asScript(context)
-                .exec(context, scope)
-        } catch (@SuppressWarnings("TooGenericExceptionCaught") e: Exception) {
-            when (expression.onFailure) {
-                OnFailure.TRUE -> true
-                OnFailure.FALSE -> false
-                OnFailure.THROW -> throw e
-            }
-        }
+        return true == expression.asScript(context)
+            .exec(context, scope)
     }
 
     private fun Expression.asScript(context: Context): Script {

--- a/src/test/kotlin/com/rapatao/projects/ruleset/engine/EvaluatorTest.kt
+++ b/src/test/kotlin/com/rapatao/projects/ruleset/engine/EvaluatorTest.kt
@@ -26,6 +26,9 @@ internal class EvaluatorTest {
 
         @JvmStatic
         fun tests() = TestData.allCases()
+
+        @JvmStatic
+        fun onFailure() = TestData.onFailureCases()
     }
 
     @ParameterizedTest
@@ -34,6 +37,20 @@ internal class EvaluatorTest {
         println(ruleSet)
 
         doEvaluationTest(engine, ruleSet, expected)
+    }
+
+    @ParameterizedTest
+    @MethodSource("onFailure")
+    fun `assert onFailure`(engine: EvalEngine, ruleSet: Expression, expected: Boolean, isError: Boolean) {
+        println(ruleSet)
+
+        if (isError) {
+            assertThrows<Exception> {
+                doEvaluationTest(engine, ruleSet, expected)
+            }
+        } else {
+            doEvaluationTest(engine, ruleSet, expected)
+        }
     }
 
     @Test

--- a/src/test/kotlin/com/rapatao/projects/ruleset/engine/cases/OnFailureCases.kt
+++ b/src/test/kotlin/com/rapatao/projects/ruleset/engine/cases/OnFailureCases.kt
@@ -1,0 +1,137 @@
+package com.rapatao.projects.ruleset.engine.cases
+
+import com.rapatao.projects.ruleset.engine.types.Expression
+import com.rapatao.projects.ruleset.engine.types.OnFailure
+import com.rapatao.projects.ruleset.engine.types.builder.equalsTo
+import org.junit.jupiter.params.provider.Arguments
+
+object OnFailureCases {
+
+    fun cases(): List<Arguments> = anyMatchCases() + allMatchCases() + noneMatchCases()
+
+    private fun anyMatchCases(): List<Arguments> = listOf(
+        Arguments.of(
+            Expression(
+                anyMatch = listOf(
+                    "item.non.existing.field" equalsTo 10,
+                )
+            ),
+            false,
+            true,
+        ),
+        Arguments.of(
+            Expression(
+                onFailure = OnFailure.THROW,
+                anyMatch = listOf(
+                    "item.non.existing.field" equalsTo 10,
+                )
+            ),
+            false,
+            true,
+        ),
+        Arguments.of(
+            Expression(
+                onFailure = OnFailure.FALSE,
+                anyMatch = listOf(
+                    "item.non.existing.field" equalsTo 10,
+                )
+            ),
+            false,
+            false,
+        ),
+        Arguments.of(
+            Expression(
+                onFailure = OnFailure.TRUE,
+                anyMatch = listOf(
+                    "item.non.existing.field" equalsTo 10,
+                )
+            ),
+            true,
+            false,
+        ),
+    )
+
+    private fun allMatchCases(): List<Arguments> = listOf(
+        Arguments.of(
+            Expression(
+                allMatch = listOf(
+                    "item.non.existing.field" equalsTo 10,
+                )
+            ),
+            false,
+            true,
+        ),
+        Arguments.of(
+            Expression(
+                onFailure = OnFailure.THROW,
+                allMatch = listOf(
+                    "item.non.existing.field" equalsTo 10,
+                )
+            ),
+            false,
+            true,
+        ),
+        Arguments.of(
+            Expression(
+                onFailure = OnFailure.FALSE,
+                allMatch = listOf(
+                    "item.non.existing.field" equalsTo 10,
+                )
+            ),
+            false,
+            false,
+        ),
+        Arguments.of(
+            Expression(
+                onFailure = OnFailure.TRUE,
+                allMatch = listOf(
+                    "item.non.existing.field" equalsTo 10,
+                )
+            ),
+            true,
+            false,
+        ),
+    )
+
+    private fun noneMatchCases(): List<Arguments> = listOf(
+        Arguments.of(
+            Expression(
+                noneMatch = listOf(
+                    "item.non.existing.field" equalsTo 10,
+                )
+            ),
+            false,
+            true,
+        ),
+        Arguments.of(
+            Expression(
+                onFailure = OnFailure.THROW,
+                noneMatch = listOf(
+                    "item.non.existing.field" equalsTo 10,
+                )
+            ),
+            false,
+            true,
+        ),
+        Arguments.of(
+            Expression(
+                onFailure = OnFailure.FALSE,
+                noneMatch = listOf(
+                    "item.non.existing.field" equalsTo 10,
+                )
+            ),
+            false,
+            false,
+        ),
+        Arguments.of(
+            Expression(
+                onFailure = OnFailure.TRUE,
+                noneMatch = listOf(
+                    "item.non.existing.field" equalsTo 10,
+                )
+            ),
+            true,
+            false,
+        ),
+    )
+}

--- a/src/test/kotlin/com/rapatao/projects/ruleset/engine/cases/TestData.kt
+++ b/src/test/kotlin/com/rapatao/projects/ruleset/engine/cases/TestData.kt
@@ -28,4 +28,10 @@ object TestData {
             Arguments.of(engine.get().first { it is EvalEngine }, *it.get())
         }
     }
+
+    fun onFailureCases(): List<Arguments> = (OnFailureCases.cases()).flatMap {
+        engines().map { engine ->
+            Arguments.of(engine.get().first { it is EvalEngine }, *it.get())
+        }
+    }
 }

--- a/src/test/kotlin/com/rapatao/projects/ruleset/engine/helper/Helper.kt
+++ b/src/test/kotlin/com/rapatao/projects/ruleset/engine/helper/Helper.kt
@@ -22,7 +22,7 @@ object Helper {
         val evaluator = Evaluator(engine = engine)
 
         assertThat(
-            evaluator.evaluate(rule = ruleSet, inputData = TestData.inputData),
+            evaluator.evaluate(expression = ruleSet, inputData = TestData.inputData),
             equalTo(expected)
         )
     }


### PR DESCRIPTION
Today, if an expression evaluation fails, it is only possible to set a behavior at the expression level, which means that in the grouped expression, each of them needs to have its own `onFailure` attribute set.

Within this change, the `onFailure` on the parent expression is now respected, so, if the evaluation of any expression fails, the parent configuration will be used when the expression doesn't override its default throwing behavior.