### PR TITLE
feat: expose rhino context and scope

### DIFF
--- a/src/main/kotlin/com/rapatao/projects/ruleset/engine/evaluator/rhino/RhinoContext.kt
+++ b/src/main/kotlin/com/rapatao/projects/ruleset/engine/evaluator/rhino/RhinoContext.kt
@@ -11,8 +11,8 @@ import org.mozilla.javascript.ScriptableObject
  * RhinoContext is a class that implements the EvalContext interface.
  * It provides the ability to process expressions using the Rhino JavaScript engine.
  *
- * @param context The Rhino Context object.
- * @param scope The ScriptableObject representing the scope in which the expressions will be executed.
+ * @property context The Rhino Context object.
+ * @property scope The ScriptableObject representing the scope in which the expressions will be executed.
  */
 class RhinoContext(
     private val context: Context,
@@ -38,6 +38,20 @@ class RhinoContext(
             }
         }
     }
+
+    /**
+     * Returns the Rhino context.
+     *
+     * @return The Rhino context.
+     */
+    fun context() = context
+
+    /**
+     * Returns the Rhino scope.
+     *
+     * @return The Rhino scope.
+     */
+    fun scope() = scope
 
     private fun Expression.asScript(context: Context): Script {
         val script = Parser.parse(this)


### PR DESCRIPTION
Add method in `RhinoContext` class to expose the `Context` and the `Scope` (`ScriptableObject`) from `Rhino`