### PR TITLE
feat: add support to CONTAINS operations

### DIFF
--- a/JSON.md
+++ b/JSON.md
@@ -120,7 +120,7 @@ To see more details, check its source: [here](src/test/kotlin/com/rapatao/projec
 {
   "left" : "field",
   "operator" : "STARTS_WITH",
-  "right" : "\"fi\""
+  "right" : "\"value\""
 }
 ```
 
@@ -130,7 +130,17 @@ To see more details, check its source: [here](src/test/kotlin/com/rapatao/projec
 {
   "left" : "field",
   "operator" : "ENDS_WITH",
-  "right" : "\"ld\""
+  "right" : "\"value\""
+}
+```
+
+* contains:
+
+```json
+{
+  "left" : "field",
+  "operator" : "CONTAINS",
+  "right" : "\"value\""
 }
 ```
 
@@ -1744,6 +1754,70 @@ To see more details, check its source: [here](src/test/kotlin/com/rapatao/projec
       "right" : "1000"
     } ]
   } ]
+}
+```
+
+```json
+{
+  "left" : "item.name",
+  "operator" : "STARTS_WITH",
+  "right" : "\"product\""
+}
+```
+
+```json
+{
+  "left" : "item.name",
+  "operator" : "STARTS_WITH",
+  "right" : "\"name\""
+}
+```
+
+```json
+{
+  "left" : "item.name",
+  "operator" : "ENDS_WITH",
+  "right" : "\"name\""
+}
+```
+
+```json
+{
+  "left" : "item.name",
+  "operator" : "ENDS_WITH",
+  "right" : "\"product\""
+}
+```
+
+```json
+{
+  "left" : "item.name",
+  "operator" : "CONTAINS",
+  "right" : "\"duct\""
+}
+```
+
+```json
+{
+  "left" : "item.name",
+  "operator" : "CONTAINS",
+  "right" : "\"different value\""
+}
+```
+
+```json
+{
+  "left" : "item.tags",
+  "operator" : "CONTAINS",
+  "right" : "\"test\""
+}
+```
+
+```json
+{
+  "left" : "item.tags",
+  "operator" : "CONTAINS",
+  "right" : "\"different value\""
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,16 +36,17 @@ builder: `com.rapatao.projects.ruleset.engine.types.builder.ExpressionBuilder`
 
 To create custom operations, just extends the interface `com.rapatao.projects.ruleset.engine.types.Expression`
 
-| operator              | description                                             |
-|-----------------------|---------------------------------------------------------|
-| EQUALS                | Represents the equals operator (`==`)                   |
-| NOT_EQUALS            | Represents the not equals operator (`!=`)               |
-| GREATER_THAN          | Represents the greater than operator (`>`)              |
-| GREATER_OR_EQUAL_THAN | Represents the greater than or equal to operator (`>=`) |
-| LESS_THAN             | Represents the less than operator (`<`)                 |
-| LESS_OR_EQUAL_THAN    | Represents the less than or equal to operator (`<=`)    |
-| STARTS_WITH           | Represents the `startsWith` operation                   |
-| ENDS_WITH             | Represents the `endsWith` operation                     |
+| operator              | description                                                                                                                             |
+|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| EQUALS                | Represents the equality operator (==), used to check if two values are equal.                                                           |
+| NOT_EQUALS            | Represents the inequality operator (!=), used to check if two values are not equal.                                                     |
+| GREATER_THAN          | Represents the greater than operator (>), used to compare if one value is greater than another.                                         |
+| GREATER_OR_EQUAL_THAN | Represents the greater than or equal to operator (>=), used to compare if one value is greater than or equal to another.                |
+| LESS_THAN             | Represents the less than operator (<), used to compare if one value is less than another.                                               |
+| LESS_OR_EQUAL_THAN    | Represents the less than or equal to operator (<=), used to compare if one value is less than or equal to another.                      |
+| STARTS_WITH           | Represents the operation to check if a string starts with a specified sequence of characters.                                           |
+| ENDS_WITH             | Represents the operation to check if a string ends with a specified sequence of characters.                                             |
+| CONTAINS              | Represents the operation to check if a string contains a specified sequence of characters or if an array contains a particular element. |
 
 ### Examples
 
@@ -74,9 +75,11 @@ To create custom operations, just extends the interface `com.rapatao.projects.ru
 
 "field" lessOrEqualThan 10
 
-"field" startsWith "\"fie\""
+"field" startsWith "\"value\""
 
-"field" endsWith "\"eld\""
+"field" endsWith "\"value\""
+
+"field" expContains "\"value\""
 ````
 
 ## Supported group operations

--- a/src/main/kotlin/com/rapatao/projects/ruleset/engine/evaluator/rhino/Parser.kt
+++ b/src/main/kotlin/com/rapatao/projects/ruleset/engine/evaluator/rhino/Parser.kt
@@ -13,12 +13,25 @@ internal object Parser {
             Operator.NOT_EQUALS -> "!=".formatComparison(expression)
             Operator.STARTS_WITH -> "startsWith".formatWithOperation(expression)
             Operator.ENDS_WITH -> "endsWith".formatWithOperation(expression)
+            Operator.CONTAINS -> formatContainsOperation(expression)
             else -> "==".formatComparison(expression)
         }
     }
 
-    private fun String.formatComparison(expression: Expression) = "(${expression.left}) $this (${expression.right})"
+    private fun String.formatComparison(expression: Expression) =
+        "(${expression.left}) $this (${expression.right})"
 
     private fun String.formatWithOperation(expression: Expression) =
         "${expression.left}.${this}(${expression.right})"
+
+    private fun formatContainsOperation(expression: Expression) =
+        """
+        (function() {
+            if (Array.isArray(${expression.left})) {
+                return ${expression.left}.includes(${expression.right})
+            } else {
+                return ${expression.left}.indexOf(${expression.right}) !== -1
+            }
+        })()
+        """.trimIndent()
 }

--- a/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/Operator.kt
+++ b/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/Operator.kt
@@ -1,26 +1,55 @@
 package com.rapatao.projects.ruleset.engine.types
 
 /**
- * Enum class for different operators.
- *
- * This enum class represents various operators that can be used for comparison or evaluation operations.
- * The available operators are:
- * - EQUALS:     Represents the equals operator (==).
- * - NOT_EQUALS: Represents the not equals operator (!=).
- * - GREATER_THAN: Represents the greater than operator (>).
- * - GREATER_OR_EQUAL_THAN: Represents the greater than or equal to operator (>=).
- * - LESS_THAN: Represents the less than operator (<).
- * - LESS_OR_EQUAL_THAN: Represents the less than or equal to operator (<=).
- * - STARTS_WITH: Represents the startsWith operation.
- * - ENDS_WITH: Represents the endsWith operation.
+ * This enum class defines a set of operators that can be utilized in different contexts such as string comparison,
+ * numerical comparison, or array element verification.
  */
 enum class Operator {
+    /**
+     * Represents the equality operator (==), used to check if two values are equal.
+     */
     EQUALS,
+
+    /**
+     * Represents the inequality operator (!=), used to check if two values are not equal.
+     */
     NOT_EQUALS,
+
+    /**
+     * Represents the greater than operator (>), used to compare if one value is greater than another.
+     */
     GREATER_THAN,
+
+    /**
+     * Represents the greater than or equal to operator (>=), used to compare if one value is greater than or equal to
+     * another.
+     */
     GREATER_OR_EQUAL_THAN,
+
+    /**
+     * Represents the less than operator (<), used to compare if one value is less than another.
+     */
     LESS_THAN,
+
+    /**
+     * Represents the less than or equal to operator (<=), used to compare if one value is less than or equal to
+     * another.
+     */
     LESS_OR_EQUAL_THAN,
+
+    /**
+     * Represents the operation to check if a string starts with a specified sequence of characters.
+     */
     STARTS_WITH,
+
+    /**
+     * Represents the operation to check if a string ends with a specified sequence of characters.
+     */
     ENDS_WITH,
+
+    /**
+     * Represents the operation to check if a string contains a specified sequence of characters or if an array contains
+     * a particular element.
+     */
+    CONTAINS,
 }

--- a/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/builder/ExpressionBuilder.kt
+++ b/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/builder/ExpressionBuilder.kt
@@ -2,6 +2,7 @@ package com.rapatao.projects.ruleset.engine.types.builder
 
 import com.rapatao.projects.ruleset.engine.types.Expression
 import com.rapatao.projects.ruleset.engine.types.Operator
+import com.rapatao.projects.ruleset.engine.types.Operator.CONTAINS
 import com.rapatao.projects.ruleset.engine.types.Operator.ENDS_WITH
 import com.rapatao.projects.ruleset.engine.types.Operator.EQUALS
 import com.rapatao.projects.ruleset.engine.types.Operator.GREATER_OR_EQUAL_THAN
@@ -56,6 +57,7 @@ object ExpressionBuilder {
      *
      * @param left The left-hand side of the expression.
      */
+    @Suppress("TooManyFunctions")
     class Builder(private val left: Any?) {
         /**
          * Creates an expression that represents the "equals to" comparison between the left operand and the right
@@ -144,6 +146,18 @@ object ExpressionBuilder {
          */
         fun endsWith(right: Any?) = Expression(
             left = left, operator = ENDS_WITH, right = right
+        )
+
+        /**
+         * Creates an expression to check if the left operand contains the right operand.
+         * If the left operand is a string, it checks if the string contains the value of the right operand.
+         * If the left operand is a list, it checks if the list contains the right operand.
+         *
+         * @param right The value to be checked for containment within the left operand. Can be of any type.
+         * @return An [Expression] object representing the containment check, with the operator set to CONTAINS.
+         */
+        fun contains(right: Any?) = Expression(
+            left = left, operator = CONTAINS, right = right
         )
     }
 }

--- a/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/builder/extensions/ContainsExtensions.kt
+++ b/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/builder/extensions/ContainsExtensions.kt
@@ -1,0 +1,22 @@
+package com.rapatao.projects.ruleset.engine.types.builder.extensions
+
+import com.rapatao.projects.ruleset.engine.types.Expression
+import com.rapatao.projects.ruleset.engine.types.builder.ExpressionBuilder
+
+/**
+ * Creates an expression to check if the current string contains the specified substring.
+ *
+ * @receiver The string in which to check for the presence of the substring.
+ * @param right The substring to search for within the current string.
+ * @return An [Expression] object representing the containment check, with the operator set to CONTAINS.
+ */
+infix fun String.expContains(right: String): Expression = ExpressionBuilder.left(this).contains(right)
+
+/**
+ * Creates an expression to check if the current list contains the specified element.
+ *
+ * @receiver The list in which to check for the presence of the element.
+ * @param right The element to search for within the current list.
+ * @return An [Expression] object representing the containment check, with the operator set to CONTAINS.
+ */
+infix fun List<Any>.expContains(right: Any): Expression = ExpressionBuilder.left(this).contains(right)

--- a/src/test/kotlin/com/rapatao/projects/ruleset/SerializationExamplesBuilder.kt
+++ b/src/test/kotlin/com/rapatao/projects/ruleset/SerializationExamplesBuilder.kt
@@ -2,14 +2,14 @@ package com.rapatao.projects.ruleset
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.rapatao.projects.ruleset.engine.cases.ExpressionCases
-import com.rapatao.projects.ruleset.engine.cases.MatcherCases
+import com.rapatao.projects.ruleset.engine.cases.TestData
 import com.rapatao.projects.ruleset.engine.types.Expression
 import com.rapatao.projects.ruleset.engine.types.builder.MatcherBuilder.allMatch
 import com.rapatao.projects.ruleset.engine.types.builder.MatcherBuilder.anyMatch
 import com.rapatao.projects.ruleset.engine.types.builder.MatcherBuilder.noneMatch
 import com.rapatao.projects.ruleset.engine.types.builder.extensions.endsWith
 import com.rapatao.projects.ruleset.engine.types.builder.extensions.equalsTo
+import com.rapatao.projects.ruleset.engine.types.builder.extensions.expContains
 import com.rapatao.projects.ruleset.engine.types.builder.extensions.greaterOrEqualThan
 import com.rapatao.projects.ruleset.engine.types.builder.extensions.greaterThan
 import com.rapatao.projects.ruleset.engine.types.builder.extensions.isFalse
@@ -61,10 +61,13 @@ internal class SerializationExamplesBuilder {
         "field" lessOrEqualThan 10,
 
         "* startsWith:",
-        "field" startsWith "\"fi\"",
+        "field" startsWith "\"value\"",
 
         "* endsWith:",
-        "field" endsWith "\"ld\"",
+        "field" endsWith "\"value\"",
+
+        "* contains:",
+        "field" expContains "\"value\"",
 
         "* allMatch: ",
         allMatch(
@@ -101,9 +104,9 @@ internal class SerializationExamplesBuilder {
         ),
     )
 
-    private val casesFromTests =
-        ExpressionCases.cases().flatMap { it.get().toList() }.filterIsInstance<Expression>() +
-            MatcherCases.cases().flatMap { it.get().toList() }.filterIsInstance<Expression>()
+    private val casesFromTests = TestData.allCases()
+        .flatMap { it.get().toList() }
+        .filterIsInstance<Expression>()
 
     @Test
     fun print() {

--- a/src/test/kotlin/com/rapatao/projects/ruleset/engine/cases/ContainsCases.kt
+++ b/src/test/kotlin/com/rapatao/projects/ruleset/engine/cases/ContainsCases.kt
@@ -1,0 +1,25 @@
+package com.rapatao.projects.ruleset.engine.cases
+
+import com.rapatao.projects.ruleset.engine.types.builder.extensions.expContains
+import org.junit.jupiter.params.provider.Arguments
+
+object ContainsCases {
+    fun cases(): List<Arguments> = listOf(
+        Arguments.of(
+            "item.name" expContains "\"duct\"",
+            true,
+        ),
+        Arguments.of(
+            "item.name" expContains "\"different value\"",
+            false,
+        ),
+        Arguments.of(
+            "item.tags" expContains "\"test\"",
+            true,
+        ),
+        Arguments.of(
+            "item.tags" expContains "\"different value\"",
+            false,
+        ),
+    )
+}

--- a/src/test/kotlin/com/rapatao/projects/ruleset/engine/cases/TestData.kt
+++ b/src/test/kotlin/com/rapatao/projects/ruleset/engine/cases/TestData.kt
@@ -16,24 +16,36 @@ object TestData {
         val trueValue: Boolean = true,
         val falseValue: Boolean = false,
         val name: String,
+        val tags: List<String>,
     )
 
     val inputData = RequestData(
-        item = Item(name = "product name", price = BigDecimal.TEN)
+        item = Item(
+            name = "product name",
+            price = BigDecimal.TEN,
+            tags = listOf(
+                "test", "brand-new"
+            )
+        )
     )
 
     fun engines(): List<Arguments> = listOf(Arguments.of(RhinoEvalEngine()))
 
-    fun allCases(): List<Arguments> =
-        (ExpressionCases.cases() + MatcherCases.cases() + OperatorWithCases.cases()).flatMap {
-            engines().map { engine ->
-                Arguments.of(engine.get().first { it is EvalEngine }, *it.get())
-            }
+    fun allCases(): List<Arguments> = getCases().flatMap {
+        engines().map { engine ->
+            Arguments.of(engine.get().first { it is EvalEngine }, *it.get())
         }
+    }
 
     fun onFailureCases(): List<Arguments> = (OnFailureCases.cases()).flatMap {
         engines().map { engine ->
             Arguments.of(engine.get().first { it is EvalEngine }, *it.get())
         }
     }
+
+    private fun getCases() =
+        ExpressionCases.cases() +
+            MatcherCases.cases() +
+            OperatorWithCases.cases() +
+            ContainsCases.cases()
 }

--- a/src/test/kotlin/com/rapatao/projects/ruleset/engine/evaluator/rhino/ParserTest.kt
+++ b/src/test/kotlin/com/rapatao/projects/ruleset/engine/evaluator/rhino/ParserTest.kt
@@ -4,6 +4,7 @@ import com.rapatao.projects.ruleset.engine.types.Expression
 import com.rapatao.projects.ruleset.engine.types.Operator
 import com.rapatao.projects.ruleset.engine.types.builder.extensions.endsWith
 import com.rapatao.projects.ruleset.engine.types.builder.extensions.equalsTo
+import com.rapatao.projects.ruleset.engine.types.builder.extensions.expContains
 import com.rapatao.projects.ruleset.engine.types.builder.extensions.greaterOrEqualThan
 import com.rapatao.projects.ruleset.engine.types.builder.extensions.greaterThan
 import com.rapatao.projects.ruleset.engine.types.builder.extensions.lessOrEqualThan
@@ -47,6 +48,9 @@ class ParserTest {
             ),
             Arguments.of(
                 ("field" endsWith 10),
+            ),
+            Arguments.of(
+                ("field" expContains "iel"),
             ),
         )
     }


### PR DESCRIPTION
This change adds a new operator `CONTAINS` that can be used to assert data by checking part of its content.

When the `left` operand is a `string` it will compare if any part of the given string contains the given `right` operand.

When the `left`operand is an `array` it will compare if any elements of the given array contains the given `right` operand.