### PR TITLE
fix: Kotlin evaluator is not supporting nullable values

### DIFF
--- a/core/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/builder/extensions/BooleanExtensions.kt
+++ b/core/src/main/kotlin/com/rapatao/projects/ruleset/engine/types/builder/extensions/BooleanExtensions.kt
@@ -23,7 +23,7 @@ fun Any.isFalse(): Expression = ExpressionBuilder.isFalse(this)
  * @param right The object to compare with.
  * @return An expression representing the equality comparison between the current object and the given object.
  */
-infix fun Any.equalsTo(right: Any): Expression = ExpressionBuilder.left(this).equalsTo(right)
+infix fun Any.equalsTo(right: Any?): Expression = ExpressionBuilder.left(this).equalsTo(right)
 
 /**
  * Compares this object with the specified [right] object for inequality.
@@ -31,5 +31,5 @@ infix fun Any.equalsTo(right: Any): Expression = ExpressionBuilder.left(this).eq
  * @param right The object to compare with this object.
  * @return An [Expression] representing the inequality comparison result.
  */
-infix fun Any.notEqualsTo(right: Any): Expression = ExpressionBuilder.left(this).notEqualsTo(right)
+infix fun Any.notEqualsTo(right: Any?): Expression = ExpressionBuilder.left(this).notEqualsTo(right)
 

--- a/jackson/src/test/kotlin/com/rapatao/projects/ruleset/jackson/SerializationExamplesBuilder.kt
+++ b/jackson/src/test/kotlin/com/rapatao/projects/ruleset/jackson/SerializationExamplesBuilder.kt
@@ -102,9 +102,17 @@ internal class SerializationExamplesBuilder {
         ),
     )
 
-    private val casesFromTests = TestData.allCases()
+    private val casesFromTests = TestData.cases()
         .flatMap { it.get().toList() }
         .filterIsInstance<Expression>()
+        .filter {
+            // remove from serialization example rules that one of the operands is null
+            it.isValid() &&
+                (
+                    (it.left != null && it.right != null) ||
+                        !it.noneMatch.isNullOrEmpty() || !it.allMatch.isNullOrEmpty() || !it.anyMatch.isNullOrEmpty()
+                    )
+        }
         .toSet()
 
     @Test

--- a/jackson/src/test/kotlin/com/rapatao/projects/ruleset/jackson/SerializationTest.kt
+++ b/jackson/src/test/kotlin/com/rapatao/projects/ruleset/jackson/SerializationTest.kt
@@ -24,7 +24,7 @@ class SerializationTest {
 
     companion object {
         @JvmStatic
-        fun tests() = TestData.allCases()
+        fun tests() = TestData.cases()
     }
 
     @ParameterizedTest

--- a/kotlin-evaluator/src/main/kotlin/com/rapatao/projects/ruleset/engine/evaluator/kotlin/KotlinContext.kt
+++ b/kotlin-evaluator/src/main/kotlin/com/rapatao/projects/ruleset/engine/evaluator/kotlin/KotlinContext.kt
@@ -51,10 +51,14 @@ class KotlinContext(
                 key.toBooleanStrictOrNull()
             },
             {
-                inputData.getOrElse(key) {
+                inputData[key]
+            },
+            {
+                if (!inputData.containsKey(key)) {
                     throw NoSuchElementException("$key not found")
                 }
-            },
+                null
+            }
         ).firstNotNullOfOrNull { it() }
     }
 

--- a/tests/src/main/kotlin/com/rapatao/projects/ruleset/engine/BaseEvaluatorTest.kt
+++ b/tests/src/main/kotlin/com/rapatao/projects/ruleset/engine/BaseEvaluatorTest.kt
@@ -25,7 +25,7 @@ abstract class BaseEvaluatorTest(
     companion object {
 
         @JvmStatic
-        fun tests() = TestData.allCases()
+        fun tests() = TestData.cases()
 
         @JvmStatic
         fun onFailure() = TestData.onFailureCases()

--- a/tests/src/main/kotlin/com/rapatao/projects/ruleset/engine/cases/ExpressionCases.kt
+++ b/tests/src/main/kotlin/com/rapatao/projects/ruleset/engine/cases/ExpressionCases.kt
@@ -146,7 +146,12 @@ object ExpressionCases {
             "item.price" equalsTo 0,
             false
         ),
+        Arguments.of(
+            "item.nullableStr" equalsTo null,
+            true
+        )
     )
+
     @Suppress("MagicNumber")
     private fun notEqualsCases() = listOf(
         Arguments.of(

--- a/tests/src/main/kotlin/com/rapatao/projects/ruleset/engine/cases/TestData.kt
+++ b/tests/src/main/kotlin/com/rapatao/projects/ruleset/engine/cases/TestData.kt
@@ -16,6 +16,7 @@ object TestData {
         val name: String,
         val tags: List<String>,
         val arrTags: Array<String>,
+        val nullableStr: String? = null,
     )
 
     val inputData = RequestData(
@@ -28,8 +29,6 @@ object TestData {
             arrTags = arrayOf("in_array")
         )
     )
-
-    fun allCases(): List<Arguments> = cases()
 
     fun onFailureCases(): List<Arguments> = (OnFailureCases.cases())
 


### PR DESCRIPTION
When evaluating an expression using the Kotlin Evaluator, when the input map contains nullable values, the evaluator throws an exception to key not found instead of returning null.

This change fixes it, returning null when a key is present but has null as value, throwing the exception only when the key is not present in the input map.