### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - '**/**'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rapatao/ruleset-engine/security/code-scanning/2](https://github.com/rapatao/ruleset-engine/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/tests.yaml` at the workflow root so it applies to all jobs (currently just `tests`).  
The least-privilege fix that preserves behavior is:

- `contents: read`

This is sufficient for `actions/checkout@v4` and running tests. No additional imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
