### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rapatao/ruleset-engine/security/code-scanning/1](https://github.com/rapatao/ruleset-engine/security/code-scanning/1)

Add an explicit `permissions` block with least privilege to the workflow.  
Best fix here: set workflow-level permissions to:

```yaml
permissions:
  contents: read
```

This is the minimal documented baseline and is sufficient for `actions/checkout` in a typical publish workflow that does not write back to the repo. It preserves existing behavior while constraining `GITHUB_TOKEN` scope.

Change location: `.github/workflows/publish.yaml`, directly under `on:` block (before `jobs:`), so it applies to all jobs unless overridden.

No imports, methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
